### PR TITLE
Added LDAP extension so that we can be able to interact with the Serv…

### DIFF
--- a/.docker/php/dockerfile
+++ b/.docker/php/dockerfile
@@ -4,7 +4,7 @@ ENV USER=www
 ENV GROUP=www
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install libldap2-dev -y \
     git \
     curl \
     libpng-dev \
@@ -15,6 +15,10 @@ RUN apt-get update && apt-get install -y \
 
 # Clear cache
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/
+
+RUN docker-php-ext-install ldap
 
 # Set timezone
 RUN rm /etc/localtime \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -201,6 +201,5 @@ services:
       - /var/lib/mysql
     networks:
       coolstuff-enterprise-network:
-      tribes-app-network:
         aliases:
           - mysql_testing


### PR DESCRIPTION
We initially checked  for the running **OS**  and then followed instructions from [westbeliner's](https://gist.github.com/westberliner/d8e622d052e01c9368b9) gits on how to add LDAP support within a `php-fpm` setup.

The build ran successfully which confirms the extension to be installed successfully.